### PR TITLE
Allow purescript-chai to work in Node.js as well as browser

### DIFF
--- a/src/Test/Chai.purs
+++ b/src/Test/Chai.purs
@@ -16,11 +16,19 @@ data Expect              = Expect
 data Error               = Error 
 
 foreign import chai
-  "var chai = typeof chai === 'undefined' ? require('chai') : chai"
+  """var chai = (function() {
+    if (typeof window === 'undefined') {
+      // this is Node.js
+      return require('chai');
+    } else {
+      // in the browser; `chai` should already be defined on `window`
+      return window.chai;
+    }
+  })()"""
   :: forall a. a
 
 expect                   :: forall a. a -> Expect
-expect                   = unsafeForeignFunction ["chai", "source", ""] "chai.expect(source)" $ chai
+expect                   = unsafeForeignFunction ["chai", "source"] "chai.expect(source)" $ chai
 
 type Expectation         = forall a e. Expect -> a -> Eff (chai :: Chai | e) Unit
 bindExpectation        x = unsafeForeignProcedure ["expect", "target", ""] $ "expect." ++ x ++ "(target)"


### PR DESCRIPTION
I tested this by running the tests for purescript-timers via karma as well as via mocha in node.js.

Note that I've left chai out of package.json on purpose - there's no reason to include it there; only users of this library need to add chai to package.json.
